### PR TITLE
chore: remove "scenes" field in WriteRecord struct

### DIFF
--- a/cu-core/src/data.rs
+++ b/cu-core/src/data.rs
@@ -8,11 +8,6 @@ pub struct WriteRecord {
 
     /// Volume of data written in byte.
     pub byte_count: u32,
-
-    /// Use Scenarios of the record.
-    ///
-    /// Collector can procces the record according to the usage scenarios.
-    pub scenes: Scenes,
 }
 
 /// The ReadRecord records some data about consumed rcu.
@@ -38,11 +33,6 @@ pub struct ReadRecord {
     ///
     /// Unit is byte.
     pub network_egress: u32,
-
-    /// Use Scenarios of the record.
-    ///
-    /// Collector can procces the record according to the usage scenarios.
-    pub scenes: Scenes,
 }
 
 /// Use Scenarios of the record.

--- a/cu-core/src/registry.rs
+++ b/cu-core/src/registry.rs
@@ -45,7 +45,7 @@ impl Registry {
     }
 
     /// A base API for recording WCU consumption.
-    pub fn record_write(&self, info: WriteRecord) {
+    pub fn record_write(&self, record: WriteRecord) {
         let collector = self.inner.collector.read();
 
         let collector = match collector.as_ref() {
@@ -53,11 +53,11 @@ impl Registry {
             None => return,
         };
 
-        collector.on_write(info);
+        collector.on_write(record);
     }
 
     /// A base API for recording RCU consumption.
-    pub fn record_read(&self, info: ReadRecord) {
+    pub fn record_read(&self, record: ReadRecord) {
         let collector = self.inner.collector.read();
 
         let collector = match collector.as_ref() {
@@ -65,8 +65,6 @@ impl Registry {
             None => return,
         };
 
-        collector.on_read(info);
+        collector.on_read(record);
     }
-
-    // TODO(fys): provide better api design
 }

--- a/cu-example/examples/simple.rs
+++ b/cu-example/examples/simple.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use cu_core::data::ReadRecord;
-use cu_core::data::Scenes;
 use cu_core::data::WriteRecord;
 use cu_core::global::global_registry;
 use cu_core::registry::Registry;
@@ -46,7 +45,6 @@ async fn do_some_record(r: Registry) {
             table: None,
             region_num: None,
             byte_count: 10 * 1024,
-            scenes: Scenes::RateLimit,
         });
 
         r.record_read(ReadRecord {
@@ -57,7 +55,6 @@ async fn do_some_record(r: Registry) {
             cpu_time: 3,
             table_scan: 0,
             network_egress: 0,
-            scenes: Scenes::RateLimit,
         });
 
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/cu-example/src/simple_collector.rs
+++ b/cu-example/src/simple_collector.rs
@@ -8,7 +8,6 @@ use cu_core::cu_query::SchemaId;
 use cu_core::cu_query::TableId;
 use cu_core::cu_query::WcuCount;
 use cu_core::data::ReadRecord;
-use cu_core::data::Scenes;
 use cu_core::data::WriteRecord;
 use dashmap::DashMap;
 
@@ -99,10 +98,6 @@ where
     W: Send + Sync,
 {
     fn on_read(&self, record: ReadRecord) {
-        if let Scenes::DistributedScheduling = record.scenes {
-            unimplemented!()
-        }
-
         let schema_id = SchemaId {
             catalog: record.catalog.clone(),
             schema: record.schema.clone(),
@@ -114,10 +109,6 @@ where
     }
 
     fn on_write(&self, record: WriteRecord) {
-        if let Scenes::DistributedScheduling = record.scenes {
-            unimplemented!()
-        }
-
         let schema_id = SchemaId {
             catalog: record.catalog.clone(),
             schema: record.schema.clone(),


### PR DESCRIPTION
The user can create different registry instances for different usage scenarios, ex: distribute scheduling, rate limit, etc.