### PR TITLE
feat: add traffic source to meter record

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,7 @@
+[workspace.package]
+edition = "2021"
+license = "Apache-2.0"
+
 [workspace]
 members = ["meter-core", "meter-example", "meter-macros"]
+resolver = "2"

--- a/meter-core/src/data.rs
+++ b/meter-core/src/data.rs
@@ -34,97 +34,11 @@ impl ReadItem {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
-#[repr(u8)]
-#[non_exhaustive]
-pub enum TrafficSource {
-    #[default]
-    Other = 0u8,
-
-    Prometheus = 1u8,
-    Influx = 2u8,
-    HTTP = 3u8,
-    MySQL = 4u8,
-    Postgres = 5u8,
-    GRPC = 6u8,
-    OTLP = 7u8,
-}
-
-impl From<u8> for TrafficSource {
-    fn from(value: u8) -> Self {
-        match value {
-            1 => TrafficSource::Prometheus,
-            2 => TrafficSource::Influx,
-            3 => TrafficSource::HTTP,
-            4 => TrafficSource::MySQL,
-            5 => TrafficSource::Postgres,
-            6 => TrafficSource::GRPC,
-            7 => TrafficSource::OTLP,
-
-            _ => TrafficSource::Other,
-        }
-    }
-}
-
-impl From<u32> for TrafficSource {
-    fn from(value: u32) -> Self {
-        match value {
-            1 => TrafficSource::Prometheus,
-            2 => TrafficSource::Influx,
-            3 => TrafficSource::HTTP,
-            4 => TrafficSource::MySQL,
-            5 => TrafficSource::Postgres,
-            6 => TrafficSource::GRPC,
-            7 => TrafficSource::OTLP,
-
-            _ => TrafficSource::Other,
-        }
-    }
-}
-
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct MeterRecord {
     pub catalog: String,
     pub schema: String,
     pub value: u64,
-    pub source: TrafficSource,
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_traffic_source_roundtrip() {
-        assert_eq!(
-            TrafficSource::Prometheus,
-            TrafficSource::from(TrafficSource::Prometheus as u8)
-        );
-        assert_eq!(
-            TrafficSource::Influx,
-            TrafficSource::from(TrafficSource::Influx as u8)
-        );
-        assert_eq!(
-            TrafficSource::MySQL,
-            TrafficSource::from(TrafficSource::MySQL as u8)
-        );
-        assert_eq!(
-            TrafficSource::Postgres,
-            TrafficSource::from(TrafficSource::Postgres as u8)
-        );
-        assert_eq!(
-            TrafficSource::GRPC,
-            TrafficSource::from(TrafficSource::GRPC as u8)
-        );
-        assert_eq!(
-            TrafficSource::OTLP,
-            TrafficSource::from(TrafficSource::OTLP as u8)
-        );
-        assert_eq!(
-            TrafficSource::Other,
-            TrafficSource::from(TrafficSource::Other as u8)
-        );
-        assert_eq!(TrafficSource::Other, TrafficSource::from(100u8));
-    }
+    pub source: u8,
 }

--- a/meter-core/src/data.rs
+++ b/meter-core/src/data.rs
@@ -34,7 +34,7 @@ impl ReadItem {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum TrafficSource {
@@ -52,6 +52,22 @@ pub enum TrafficSource {
 
 impl From<u8> for TrafficSource {
     fn from(value: u8) -> Self {
+        match value {
+            1 => TrafficSource::Prometheus,
+            2 => TrafficSource::Influx,
+            3 => TrafficSource::HTTP,
+            4 => TrafficSource::MySQL,
+            5 => TrafficSource::Postgres,
+            6 => TrafficSource::GRPC,
+            7 => TrafficSource::OTLP,
+
+            _ => TrafficSource::Other,
+        }
+    }
+}
+
+impl From<u32> for TrafficSource {
+    fn from(value: u32) -> Self {
         match value {
             1 => TrafficSource::Prometheus,
             2 => TrafficSource::Influx,

--- a/meter-core/src/data.rs
+++ b/meter-core/src/data.rs
@@ -34,18 +34,36 @@ impl ReadItem {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum TrafficSource {
-    Prometheus,
-    Influx,
-    HTTP,
-    MySQL,
-    Postgres,
-    GRPC,
-    OTLP,
     #[default]
-    Other,
+    Other = 0u8,
+
+    Prometheus = 1u8,
+    Influx = 2u8,
+    HTTP = 3u8,
+    MySQL = 4u8,
+    Postgres = 5u8,
+    GRPC = 6u8,
+    OTLP = 7u8,
+}
+
+impl From<u8> for TrafficSource {
+    fn from(value: u8) -> Self {
+        match value {
+            1 => TrafficSource::Prometheus,
+            2 => TrafficSource::Influx,
+            3 => TrafficSource::HTTP,
+            4 => TrafficSource::MySQL,
+            5 => TrafficSource::Postgres,
+            6 => TrafficSource::GRPC,
+            7 => TrafficSource::OTLP,
+
+            _ => TrafficSource::Other,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -55,4 +73,42 @@ pub struct MeterRecord {
     pub schema: String,
     pub value: u64,
     pub source: TrafficSource,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_traffic_source_roundtrip() {
+        assert_eq!(
+            TrafficSource::Prometheus,
+            TrafficSource::from(TrafficSource::Prometheus as u8)
+        );
+        assert_eq!(
+            TrafficSource::Influx,
+            TrafficSource::from(TrafficSource::Influx as u8)
+        );
+        assert_eq!(
+            TrafficSource::MySQL,
+            TrafficSource::from(TrafficSource::MySQL as u8)
+        );
+        assert_eq!(
+            TrafficSource::Postgres,
+            TrafficSource::from(TrafficSource::Postgres as u8)
+        );
+        assert_eq!(
+            TrafficSource::GRPC,
+            TrafficSource::from(TrafficSource::GRPC as u8)
+        );
+        assert_eq!(
+            TrafficSource::OTLP,
+            TrafficSource::from(TrafficSource::OTLP as u8)
+        );
+        assert_eq!(
+            TrafficSource::Other,
+            TrafficSource::from(TrafficSource::Other as u8)
+        );
+        assert_eq!(TrafficSource::Other, TrafficSource::from(100u8));
+    }
 }

--- a/meter-core/src/data.rs
+++ b/meter-core/src/data.rs
@@ -34,7 +34,7 @@ impl ReadItem {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[non_exhaustive]
 pub enum TrafficSource {
     Prometheus,
@@ -44,6 +44,7 @@ pub enum TrafficSource {
     Postgres,
     GRPC,
     OTLP,
+    #[default]
     Other,
 }
 

--- a/meter-core/src/data.rs
+++ b/meter-core/src/data.rs
@@ -35,8 +35,23 @@ impl ReadItem {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
+pub enum TrafficSource {
+    Prometheus,
+    Influx,
+    HTTP,
+    MySQL,
+    Postgres,
+    GRPC,
+    OTLP,
+    Other,
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
 pub struct MeterRecord {
     pub catalog: String,
     pub schema: String,
     pub value: u64,
+    pub source: TrafficSource,
 }

--- a/meter-example/examples/simple.rs
+++ b/meter-example/examples/simple.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use meter_core::data::TrafficSource;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::info;
@@ -67,7 +68,7 @@ async fn setup_global_registry() {
 async fn do_some_record() {
     for _i in 0..20 {
         let insert_req = "String insert req".to_string();
-        let w = write_meter!("greptime", "db1", insert_req);
+        let w = write_meter!("greptime", "db1", insert_req, TrafficSource::Other);
         info!("w: {}", w);
 
         let r = read_meter!(
@@ -76,7 +77,8 @@ async fn do_some_record() {
             ReadItem {
                 cpu_time: 100000,
                 table_scan: 100000,
-            }
+            },
+            TrafficSource::Other
         );
         info!("r: {}", r);
 

--- a/meter-example/examples/simple.rs
+++ b/meter-example/examples/simple.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use meter_core::data::TrafficSource;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::info;
@@ -68,7 +67,7 @@ async fn setup_global_registry() {
 async fn do_some_record() {
     for _i in 0..20 {
         let insert_req = "String insert req".to_string();
-        let w = write_meter!("greptime", "db1", insert_req, TrafficSource::Other);
+        let w = write_meter!("greptime", "db1", insert_req, 0);
         info!("w: {}", w);
 
         let r = read_meter!(
@@ -78,7 +77,7 @@ async fn do_some_record() {
                 cpu_time: 100000,
                 table_scan: 100000,
             },
-            TrafficSource::Other
+            0
         );
         info!("r: {}", r);
 

--- a/meter-macros/src/read_meter.rs
+++ b/meter-macros/src/read_meter.rs
@@ -15,8 +15,8 @@
 #[cfg(feature = "noop")]
 #[macro_export]
 macro_rules! read_meter {
-    ($catalog: expr, $schema: expr, $item: expr) => {{
-        let _ = ($catalog, $schema, $item);
+    ($catalog: expr, $schema: expr, $item: expr, $source: expr) => {{
+        let _ = ($catalog, $schema, $item, $source);
         0 as u64
     }};
 }
@@ -31,7 +31,7 @@ macro_rules! read_meter {
 /// use meter_core::ItemCalculator;
 /// use meter_core::global::global_registry;
 /// use meter_macros::read_meter;
-/// use meter_core::data::ReadItem;
+/// use meter_core::data::{ReadItem, TrafficSource};
 ///
 /// let cpu_time_ns = 1000000000;
 /// let table_scan_bytes = 10224378;
@@ -57,12 +57,12 @@ macro_rules! read_meter {
 /// read_meter!("greptime", "public", ReadItem {
 ///     cpu_time: cpu_time_ns,
 ///     table_scan: table_scan_bytes,
-/// });
+/// }, TrafficSource::Other);
 /// ```
 #[cfg(not(feature = "noop"))]
 #[macro_export]
 macro_rules! read_meter {
-    ($catalog: expr, $schema: expr, $item: expr) => {{
+    ($catalog: expr, $schema: expr, $item: expr, $source: expr) => {{
         let r = meter_core::global::global_registry();
         let mut value = 0;
         if let Some(calc) = r.get_calculator() {
@@ -71,6 +71,7 @@ macro_rules! read_meter {
                 catalog: $catalog.into(),
                 schema: $schema.into(),
                 value: value,
+                source: source,
             };
             meter_core::global::global_registry().record_read(record);
         }

--- a/meter-macros/src/read_meter.rs
+++ b/meter-macros/src/read_meter.rs
@@ -57,7 +57,7 @@ macro_rules! read_meter {
 /// read_meter!("greptime", "public", ReadItem {
 ///     cpu_time: cpu_time_ns,
 ///     table_scan: table_scan_bytes,
-/// }, TrafficSource::Other);
+/// }, 0);
 /// ```
 #[cfg(not(feature = "noop"))]
 #[macro_export]

--- a/meter-macros/src/read_meter.rs
+++ b/meter-macros/src/read_meter.rs
@@ -31,7 +31,7 @@ macro_rules! read_meter {
 /// use meter_core::ItemCalculator;
 /// use meter_core::global::global_registry;
 /// use meter_macros::read_meter;
-/// use meter_core::data::{ReadItem, TrafficSource};
+/// use meter_core::data::ReadItem;
 ///
 /// let cpu_time_ns = 1000000000;
 /// let table_scan_bytes = 10224378;

--- a/meter-macros/src/write_meter.rs
+++ b/meter-macros/src/write_meter.rs
@@ -30,7 +30,6 @@ macro_rules! write_meter {
 ///
 /// use meter_core::ItemCalculator;
 /// use meter_core::global::global_registry;
-/// use meter_core::data::TrafficSource;
 /// use meter_macros::write_meter;
 ///
 /// // A struct about insert request

--- a/meter-macros/src/write_meter.rs
+++ b/meter-macros/src/write_meter.rs
@@ -51,7 +51,7 @@ macro_rules! write_meter {
 /// let registry = global_registry();
 /// registry.register_calculator(Arc::new(MockInsertCalculator));
 ///
-/// write_meter!("greptime", "public", MockInsert, TrafficSource::Other);
+/// write_meter!("greptime", "public", MockInsert, 0);
 /// ```
 #[cfg(not(feature = "noop"))]
 #[macro_export]

--- a/meter-macros/src/write_meter.rs
+++ b/meter-macros/src/write_meter.rs
@@ -15,8 +15,8 @@
 #[cfg(feature = "noop")]
 #[macro_export]
 macro_rules! write_meter {
-    ($catalog: expr, $schema: expr, $write_calc: expr) => {{
-        let _ = ($catalog, $schema, &$write_calc);
+    ($catalog: expr, $schema: expr, $write_calc: expr, $source: expr) => {{
+        let _ = ($catalog, $schema, &$write_calc, $source);
         0 as u64
     }};
 }
@@ -30,6 +30,7 @@ macro_rules! write_meter {
 ///
 /// use meter_core::ItemCalculator;
 /// use meter_core::global::global_registry;
+/// use meter_core::data::TrafficSource;
 /// use meter_macros::write_meter;
 ///
 /// // A struct about insert request
@@ -50,12 +51,12 @@ macro_rules! write_meter {
 /// let registry = global_registry();
 /// registry.register_calculator(Arc::new(MockInsertCalculator));
 ///
-/// write_meter!("greptime", "public", MockInsert);
+/// write_meter!("greptime", "public", MockInsert, TrafficSource::Other);
 /// ```
 #[cfg(not(feature = "noop"))]
 #[macro_export]
 macro_rules! write_meter {
-    ($catalog: expr, $schema: expr, $req_item: expr) => {{
+    ($catalog: expr, $schema: expr, $req_item: expr, $source: expr) => {{
         let r = meter_core::global::global_registry();
         let mut value = 0;
         if let Some(calc) = r.get_calculator() {
@@ -65,6 +66,7 @@ macro_rules! write_meter {
                 catalog: $catalog.into(),
                 schema: $schema.into(),
                 value: value,
+                source: source,
             };
 
             r.record_write(record);


### PR DESCRIPTION
This patch add traffic source for `MeterRecord` so we can track the source of workloads